### PR TITLE
Raised nokogiri dependancy version and gem version

### DIFF
--- a/junit_report_generator.gemspec
+++ b/junit_report_generator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'junit_report_generator'
-  s.version     = '1.0.1'
+  s.version     = '1.0.2'
   s.license     = 'MIT'
   s.date        = '2015-08-13'
   s.summary     = 'Generating JUnit test report easily from any source.'
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.homepage    = 'https://github.com/thyrlian/JunitReportGenerator'
   s.required_ruby_version = '~> 2.0'
-  s.add_dependency 'nokogiri', '~> 1.6'
+  s.add_dependency 'nokogiri', '~> 1.7'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'minitest', '~> 5.7'
   s.add_development_dependency 'coveralls', '~> 0.8.2'


### PR DESCRIPTION
Since nokogiri gem is often >=1.7 version and it's fully compatible, it makes sense to raise the dependancy version to eliminate the need of installing older version.